### PR TITLE
로드맵 코스 리스트 API

### DIFF
--- a/src/main/java/io/devridge/api/domain/companyinfo/CompanyInfo.java
+++ b/src/main/java/io/devridge/api/domain/companyinfo/CompanyInfo.java
@@ -27,10 +27,9 @@ public class CompanyInfo extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     private Job job;
 
-    @JoinColumn(name = "service_id")
+    @JoinColumn(name = "detailed_position_id")
     @ManyToOne(fetch = FetchType.LAZY)
     private DetailedPosition detailedPosition;
-
 
     @JoinColumn(name = "company_id")
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/io/devridge/api/domain/companyinfo/CompanyInfoRepository.java
+++ b/src/main/java/io/devridge/api/domain/companyinfo/CompanyInfoRepository.java
@@ -1,9 +1,17 @@
 package io.devridge.api.domain.companyinfo;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
 
 public interface CompanyInfoRepository extends JpaRepository<CompanyInfo, Long> {
+
+    @Query("SELECT ci FROM CompanyInfo ci " +
+            "JOIN FETCH ci.company c " +
+            "JOIN FETCH ci.job j " +
+            "WHERE ci.company.id = :companyId AND ci.job.id = :jobId AND ci.detailedPosition.id = :detailPositionId")
+    Optional<CompanyInfo> findByCompanyIdAndJobIdAndDetailedPositionIdWithFetchJoin(long companyId, long jobId, long detailPositionId);
+
     Optional<CompanyInfo> findByCompanyIdAndJobIdAndDetailedPositionId(long companyId, long jobId, long detailedPositionId);
 }

--- a/src/main/java/io/devridge/api/domain/roadmap/CourseDetailRepository.java
+++ b/src/main/java/io/devridge/api/domain/roadmap/CourseDetailRepository.java
@@ -16,7 +16,6 @@ public interface CourseDetailRepository extends JpaRepository<CourseDetail, Long
 //    List<CourseDetail> getCourseDetailListByCourseIdAndCompanyIdAndJobId(@Param("courseId")long courseId, @Param("companyId") long companyId, @Param("jobId") long jobId);
     CourseDetail findByName(String courseName);
 
-
     @Query("SELECT cd FROM CourseDetail cd " +
             "JOIN Course c ON c.id = cd.course.id " +
             "JOIN CompanyRequiredAbility cra ON cra.courseDetail.id = cd.id " +

--- a/src/main/java/io/devridge/api/domain/roadmap/Roadmap.java
+++ b/src/main/java/io/devridge/api/domain/roadmap/Roadmap.java
@@ -3,6 +3,7 @@ package io.devridge.api.domain.roadmap;
 import io.devridge.api.domain.BaseTimeEntity;
 import io.devridge.api.domain.companyinfo.CompanyInfo;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -19,9 +20,6 @@ public class Roadmap extends BaseTimeEntity {
     @Column(name = "roadmap_id")
     private Long id;
 
-    @Column(name = "roadmap_order")
-    private Integer order;
-
     @Enumerated(EnumType.STRING)
     @Column(name = "roadmap_matching_flag")
     private MatchingStatus matchingFlag;
@@ -33,4 +31,12 @@ public class Roadmap extends BaseTimeEntity {
     @JoinColumn(name = "company_info_id")
     @ManyToOne(fetch = FetchType.LAZY)
     private CompanyInfo companyInfo;
+
+    @Builder
+    public Roadmap(Long id, MatchingStatus matchingFlag, Course course, CompanyInfo companyInfo) {
+        this.id = id;
+        this.matchingFlag = matchingFlag;
+        this.course = course;
+        this.companyInfo = companyInfo;
+    }
 }

--- a/src/main/java/io/devridge/api/domain/roadmap/RoadmapRepository.java
+++ b/src/main/java/io/devridge/api/domain/roadmap/RoadmapRepository.java
@@ -1,0 +1,16 @@
+package io.devridge.api.domain.roadmap;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface RoadmapRepository extends JpaRepository<Roadmap, Long> {
+
+    @Query("SELECT r FROM Roadmap r " +
+            "LEFT JOIN FETCH r.course c " +
+            "WHERE r.companyInfo.id = :companyInfoId " +
+            "ORDER BY c.order, CASE c.type WHEN 'SKILL' THEN 0 WHEN 'CS' THEN 1 ELSE 2 END")
+    List<Roadmap> getRoadmapsIncludingCoursesByCompanyInfoId(@Param("companyInfoId") Long companyInfoId);
+}

--- a/src/main/java/io/devridge/api/dto/course/CourseInfoDto.java
+++ b/src/main/java/io/devridge/api/dto/course/CourseInfoDto.java
@@ -1,8 +1,9 @@
 package io.devridge.api.dto.course;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import io.devridge.api.domain.roadmap.Course;
 import io.devridge.api.domain.roadmap.CourseType;
+import io.devridge.api.domain.roadmap.MatchingStatus;
+import io.devridge.api.domain.roadmap.Roadmap;
 import lombok.Getter;
 
 @Getter
@@ -10,13 +11,15 @@ public class CourseInfoDto {
     private final Long id;
     private final String name;
     private final CourseType type;
+    private final MatchingStatus matchingFlag;
     @JsonIgnore
-    private final int turn;
+    private final int order;
 
-    public CourseInfoDto(Course course) {
-        this.id = course.getId();
-        this.name = course.getName();
-        this.type = course.getType();
-        this.turn = course.getOrder();
+    public CourseInfoDto(Roadmap roadmap) {
+        this.id = roadmap.getCourse().getId();
+        this.name = roadmap.getCourse().getName();
+        this.type = roadmap.getCourse().getType();
+        this.matchingFlag = roadmap.getMatchingFlag();
+        this.order = roadmap.getCourse().getOrder();
     }
 }

--- a/src/main/java/io/devridge/api/dto/course/CourseListResponseDto.java
+++ b/src/main/java/io/devridge/api/dto/course/CourseListResponseDto.java
@@ -1,5 +1,6 @@
 package io.devridge.api.dto.course;
 
+import io.devridge.api.domain.companyinfo.CompanyInfo;
 import lombok.Getter;
 
 import java.util.*;
@@ -10,9 +11,9 @@ public class CourseListResponseDto {
     private final String jobName;
     private final List<CourseIndexList> courseList;
 
-    public CourseListResponseDto(CompanyJobInfo companyJobInfo, List<CourseIndexList> courseList) {
-        this.companyName = companyJobInfo.getCompanyName();
-        this.jobName = companyJobInfo.getJobName();
+    public CourseListResponseDto(CompanyInfo companyInfo, List<CourseIndexList> courseList) {
+        this.companyName = companyInfo.getCompany().getName();
+        this.jobName = companyInfo.getJob().getName();
         this.courseList = courseList;
     }
 }

--- a/src/main/java/io/devridge/api/service/CourseService.java
+++ b/src/main/java/io/devridge/api/service/CourseService.java
@@ -1,15 +1,13 @@
 package io.devridge.api.service;
 
+import io.devridge.api.domain.companyinfo.CompanyInfo;
 import io.devridge.api.domain.companyinfo.CompanyInfoRepository;
-import io.devridge.api.domain.companyinfo.CompanyJobRepository;
 import io.devridge.api.domain.roadmap.*;
 import io.devridge.api.dto.CourseDetailResponseDto;
-import io.devridge.api.dto.course.CompanyJobInfo;
 import io.devridge.api.dto.course.CourseIndexList;
 import io.devridge.api.dto.course.CourseInfoDto;
 import io.devridge.api.dto.course.CourseListResponseDto;
 import io.devridge.api.handler.ex.CompanyInfoNotFoundException;
-import io.devridge.api.handler.ex.CompanyJobNotFoundException;
 import io.devridge.api.handler.ex.CourseNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -24,19 +22,17 @@ public class CourseService {
 
     private final CourseRepository courseRepository;
     private final CourseDetailRepository courseDetailRepository;
-    private final CompanyJobRepository companyJobRepository;
     private final CompanyInfoRepository companyInfoRepository;
+    private final RoadmapRepository roadmapRepository;
 
     @Transactional(readOnly = true)
-    public CourseListResponseDto getCourseList(long companyId, long jobId) {
-        CompanyJobInfo companyJobInfo = findCompanyAndJob(companyId, jobId);
+    public CourseListResponseDto getCourseList(long companyId, long jobId, long detailPositionId) {
+        CompanyInfo companyInfo = findCompanyInfo(companyId, jobId, detailPositionId);
 
-        List<Course> courseList = courseRepository.getCourseListByJob(jobId);
+        Collection<List<CourseInfoDto>> courseListCollection = getCourseListCollection(companyInfo);
+        List<CourseIndexList> courseList = addEmptyListIfSkillNextSkill(courseListCollection);
 
-        Collection<List<CourseInfoDto>> courseListCollection = groupCourseAndMakeNewList(courseList);
-        List<CourseIndexList> courses = addEmptyListIfSkillNextSkill(courseListCollection);
-
-        return new CourseListResponseDto(companyJobInfo, courses);
+        return new CourseListResponseDto(companyInfo, courseList);
     }
 
     @Transactional(readOnly = true)
@@ -49,14 +45,17 @@ public class CourseService {
         return new CourseDetailResponseDto(course.getName(), courseDetailList);
     }
 
-    private CompanyJobInfo findCompanyAndJob(long companyId, long jobId) {
-        return companyJobRepository.findCompanyJobInfo(companyId, jobId)
-                .orElseThrow(() -> new CompanyJobNotFoundException("회사와 직무에 일치 하는 정보가 없습니다."));
+    private CompanyInfo findCompanyInfo(long companyId, long jobId, long detailPositionId) {
+        return companyInfoRepository.findByCompanyIdAndJobIdAndDetailedPositionIdWithFetchJoin(companyId, jobId, detailPositionId)
+                .orElseThrow(() -> new CompanyInfoNotFoundException("회사, 직무, 서비스에 일치 하는 회사 정보가 없습니다."));
     }
 
-    private void validateCompanyJob(long companyId, long jobId) {
-        companyJobRepository.findByCompanyIdAndJobId(companyId, jobId)
-                .orElseThrow(() -> new CompanyJobNotFoundException("회사와 직무에 일치 하는 정보가 없습니다."));
+    private Collection<List<CourseInfoDto>> getCourseListCollection(CompanyInfo companyInfo) {
+        List<Roadmap> roadmapList = roadmapRepository.getRoadmapsIncludingCoursesByCompanyInfoId(companyInfo.getId());
+        return roadmapList.stream()
+                .map(CourseInfoDto::new)
+                .collect(Collectors.groupingBy(CourseInfoDto::getOrder, TreeMap::new, Collectors.toList()))
+                .values();
     }
 
     private void validateCompanyInfo(long companyId, long jobId, long detailedPositionId) {
@@ -64,26 +63,33 @@ public class CourseService {
                 .orElseThrow(() -> new CompanyInfoNotFoundException("회사, 직무, 서비스에 일치 하는 회사 정보가 없습니다."));
     }
 
-    private Collection<List<CourseInfoDto>> groupCourseAndMakeNewList(List<Course> courseList) {
-        return courseList.stream()
-                .map(CourseInfoDto::new)
-                .collect(Collectors.groupingBy(CourseInfoDto::getTurn, TreeMap::new, Collectors.toList()))
-                .values();
-    }
-
+    /**
+     * 프론트 요구사항
+     * 1. 컬렉션의 첫 번째 항목이 SKILL인 경우 빈 리스트를 추가
+     * 2. 컬렉션의 이전 항목과 현재 항목이 모두 SKILL인 경우 빈 리스트 추가
+     */
     private List<CourseIndexList> addEmptyListIfSkillNextSkill(Collection<List<CourseInfoDto>> courseListCollection) {
         List<CourseIndexList> courseListAddEmptyList = new ArrayList<>();
         int index = 0;
         CourseType previousCourseType = null;
+        boolean isFirstItem = true;
 
         for (List<CourseInfoDto> courseInfoList : courseListCollection) {
             CourseType currentCourseType = !courseInfoList.isEmpty() ? courseInfoList.get(0).getType() : null;
-
+            // 처음에만 실행
+            if (isFirstItem) {
+                isFirstItem = false;
+                // 1. 컬렉션의 첫 번째 항목이 SKILL인 경우 빈 배열을 추가
+                if (currentCourseType == CourseType.SKILL) {
+                    courseListAddEmptyList.add(new CourseIndexList(index++, Collections.emptyList()));
+                }
+            }
+            // 2. 이전 항목이 SKILL이고 현재 항목이 SKILL인 경우 빈 배열을 추가
             if (previousCourseType == CourseType.SKILL && currentCourseType == CourseType.SKILL) {
                 courseListAddEmptyList.add(new CourseIndexList(index++, Collections.emptyList()));
             }
+            // 원래 리스트 항목 추가
             courseListAddEmptyList.add(new CourseIndexList(index++, courseInfoList));
-
             previousCourseType = currentCourseType;
         }
         return courseListAddEmptyList;

--- a/src/main/java/io/devridge/api/web/CourseController.java
+++ b/src/main/java/io/devridge/api/web/CourseController.java
@@ -19,9 +19,11 @@ public class CourseController {
     @GetMapping("/courses")
     public ResponseEntity<ApiResponse<Object>> getCourseList(
             @RequestParam("company") long companyId,
-            @RequestParam("job") long jobId
-    ) {
-        CourseListResponseDto courseList = courseService.getCourseList(companyId, jobId);
+            @RequestParam("job") long jobId,
+            @RequestParam("detailedPosition") long detailPositionId) {
+
+        CourseListResponseDto courseList = courseService.getCourseList(companyId, jobId, detailPositionId);
+
         return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success(courseList));
     }
 
@@ -30,6 +32,7 @@ public class CourseController {
                                                                 @RequestParam("company") Long companyId,
                                                                 @RequestParam("job") Long jobId,
                                                                 @RequestParam("detailedPosition") Long detailedPositionList) {
+
         CourseDetailResponseDto courseDetailResponseDto = courseService.getCourseDetailList(courseId, companyId, jobId, detailedPositionList);
 
         return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success(courseDetailResponseDto));

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -7,7 +7,6 @@ server:
     include-stacktrace: never
 
 spring:
-  # TODO 보안 필요
   jwt:
     secretKey: test123
   security:
@@ -20,10 +19,9 @@ spring:
             scope:
               - email
               - profile
-
   datasource:
-    driver-class-name: org.h2.Driver
     url: jdbc:h2:mem:test;MODE=MySQL
+    driver-class-name: org.h2.Driver
     username: sa
     password:
   h2:
@@ -33,18 +31,20 @@ spring:
     open-in-view: false
     hibernate:
       ddl-auto: create
+    show-sql: true
     properties:
       hibernate:
         default_batch_fetch_size: 100
         format_sql: true
-    show-sql: true
-    output:
-      ansi:
-        enabled: always
+    defer-datasource-initialization: true
+  output:
+    ansi:
+      enabled: always
+  sql:
+    init:
+      mode: always
 
 logging:
   level:
     org.hibernate.type: TRACE
     io.devridge.api: DEBUG
-
-

--- a/src/main/resources/application-test.yaml
+++ b/src/main/resources/application-test.yaml
@@ -31,3 +31,6 @@ spring:
     output:
       ansi:
         enabled: always
+  sql:
+    init:
+      mode: never

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,0 +1,21 @@
+-- 회사
+INSERT INTO company(company_name, created_at, updated_at) VALUES ('토스증권', '2000-01-01 00:00:00', '2000-01-01 00:00:00');
+
+-- 직무
+INSERT INTO job(job_name, created_at, updated_at) VALUES ('백엔드', '2000-01-01 00:00:00', '2000-01-01 00:00:00');
+
+-- 서비스
+INSERT INTO detailed_position(detailed_position_name, company_id, created_at, updated_at) VALUES ('Product', 1,  '2000-01-01 00:00:00', '2000-01-01 00:00:00');
+
+-- 코스
+INSERT INTO course(course_name, course_type, course_order, job_id, created_at, updated_at) VALUES ('언어', 'SKILL', 1, 1,  '2000-01-01 00:00:00', '2000-01-01 00:00:00');
+INSERT INTO course(course_name, course_type, course_order, job_id, created_at, updated_at) VALUES ('네트워크', 'CS', 2, 1,  '2000-01-01 00:00:00', '2000-01-01 00:00:00');
+INSERT INTO course(course_name, course_type, course_order, job_id, created_at, updated_at) VALUES ('프레임워크', 'SKILL', 3, 1,  '2000-01-01 00:00:00', '2000-01-01 00:00:00');
+
+-- 회사정보
+INSERT INTO company_info(company_info_content, company_id, detailed_position_id, job_id, created_at, updated_at) VALUES ('토스증권 회사정보1', 1,1,1 , '2000-01-01 00:00:00', '2000-01-01 00:00:00');
+
+-- 로드맵
+INSERT INTO roadmap(company_info_id, roadmap_matching_flag, course_id, created_at, updated_at) VALUES (1,'YES', 1,  '2000-01-01 00:00:00', '2000-01-01 00:00:00');
+INSERT INTO roadmap(company_info_id, roadmap_matching_flag, course_id, created_at, updated_at) VALUES (1, 'NO', 3, '2000-01-01 00:00:00', '2000-01-01 00:00:00');
+INSERT INTO roadmap(company_info_id, roadmap_matching_flag, course_id, created_at, updated_at) VALUES (1, 'NO', 2, '2000-01-01 00:00:00', '2000-01-01 00:00:00');

--- a/src/test/java/io/devridge/api/domain/companyinfo/CompanyInfoRepositoryTest.java
+++ b/src/test/java/io/devridge/api/domain/companyinfo/CompanyInfoRepositoryTest.java
@@ -1,0 +1,66 @@
+package io.devridge.api.domain.companyinfo;
+
+import io.devridge.api.config.JpaConfig;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+import javax.persistence.EntityManager;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ActiveProfiles("test")
+@Import(JpaConfig.class)
+@DataJpaTest
+class CompanyInfoRepositoryTest {
+
+    @Autowired
+    private CompanyInfoRepository companyInfoRepository;
+
+    @Autowired
+    private CompanyRepository companyRepository;
+
+    @Autowired
+    private JobRepository jobRepository;
+
+    @Autowired
+    private DetailedPositionRepository detailedPositionRepository;
+
+    @Autowired
+    private EntityManager em;
+
+    @DisplayName("회사ID, 직무ID, 직무 상세ID를 가지고 회사 정보를 가져올 때 FETCH JOIN을 통해 회사와 직무 정보를 같이 가져온다")
+    @Test
+    public void findByCompanyIdAndJobIdAndDetailedPositionIdWithFetchJoin_test() {
+        // given
+        Company company = companyRepository.save(Company.builder().name("test company").build());
+        Job job = jobRepository.save(Job.builder().name("test job").build());
+        DetailedPosition detailedPosition = detailedPositionRepository.save(DetailedPosition.builder().name("test detail").company(company).build());
+        companyInfoRepository.save(CompanyInfo.builder().job(job).detailedPosition(detailedPosition).company(company).build());
+        em.flush();
+        em.clear();
+
+        // when
+        CompanyInfo result = companyInfoRepository.findByCompanyIdAndJobIdAndDetailedPositionIdWithFetchJoin(company.getId(), job.getId(), detailedPosition.getId()).get();
+
+        // then
+        assertThat(result.getId()).isEqualTo(1L);
+        assertThat(result.getCompany().getName()).isEqualTo("test company");
+        assertThat(result.getJob().getName()).isEqualTo("test job");
+    }
+
+    @DisplayName("해당되는 회사정보가 없으면 빈 Optional을 반환한다")
+    @Test
+    public void findByCompanyIdAndJobIdAndDetailedPositionIdWithFetchJoin_optional_test() {
+        // given & when
+        Optional<CompanyInfo> result = companyInfoRepository.findByCompanyIdAndJobIdAndDetailedPositionIdWithFetchJoin(1L, 1L, 1L);
+
+        // then
+        assertThat(result).isEqualTo(Optional.empty());
+    }
+}

--- a/src/test/java/io/devridge/api/domain/roadmap/RoadmapRepositoryTest.java
+++ b/src/test/java/io/devridge/api/domain/roadmap/RoadmapRepositoryTest.java
@@ -1,0 +1,93 @@
+package io.devridge.api.domain.roadmap;
+
+import io.devridge.api.config.JpaConfig;
+import io.devridge.api.domain.companyinfo.*;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+import javax.persistence.EntityManager;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ActiveProfiles("test")
+@Import(JpaConfig.class)
+@DataJpaTest
+class RoadmapRepositoryTest {
+
+    @Autowired
+    private CompanyInfoRepository companyInfoRepository;
+
+    @Autowired
+    private CompanyRepository companyRepository;
+
+    @Autowired
+    private JobRepository jobRepository;
+
+    @Autowired
+    private DetailedPositionRepository detailedPositionRepository;
+
+    @Autowired
+    private CourseRepository courseRepository;
+
+    @Autowired
+    private RoadmapRepository roadmapRepository;
+
+    @Autowired
+    private EntityManager em;
+
+    @DisplayName("로드맵을 가져올 떄 코스 정보를 같이 가져오고 order 오름차순으로 정렬한다. 만약 같은 경우 SKILL이 먼저 오도록 한다.")
+    @Test
+    public void findByCompanyIdAndJobIdAndDetailedPositionIdWithFetchJoin_test() {
+        // given
+        Company company = companyRepository.save(Company.builder().name("test company").build());
+        Job job = jobRepository.save(Job.builder().name("test job").build());
+        DetailedPosition detailedPosition = detailedPositionRepository.save(DetailedPosition.builder().name("test detail").company(company).build());
+        CompanyInfo companyInfo = companyInfoRepository.save(CompanyInfo.builder().job(job).detailedPosition(detailedPosition).company(company).build());
+        Course course1 = courseRepository.save(Course.builder().job(job).name("SKILL1").type(CourseType.SKILL).order(1).build());
+        Course course2 = courseRepository.save(Course.builder().job(job).name("CS1").type(CourseType.CS).order(3).build());
+        Course course3 = courseRepository.save(Course.builder().job(job).name("CS2").type(CourseType.CS).order(2).build());
+        Course course4 = courseRepository.save(Course.builder().job(job).name("SKILL2").type(CourseType.SKILL).order(3).build());
+        roadmapRepository.save(Roadmap.builder().course(course1).companyInfo(companyInfo).matchingFlag(MatchingStatus.YES).build());
+        roadmapRepository.save(Roadmap.builder().course(course2).companyInfo(companyInfo).matchingFlag(MatchingStatus.NO).build());
+        roadmapRepository.save(Roadmap.builder().course(course3).companyInfo(companyInfo).matchingFlag(MatchingStatus.YES).build());
+        roadmapRepository.save(Roadmap.builder().course(course4).companyInfo(companyInfo).matchingFlag(MatchingStatus.NO).build());
+        em.flush();
+        em.clear();
+
+        // when
+        List<Roadmap> roadmapList = roadmapRepository.getRoadmapsIncludingCoursesByCompanyInfoId(companyInfo.getId());
+
+        // then
+        assertThat(roadmapList.size()).isEqualTo(4);
+
+        assertThat(roadmapList.get(0).getMatchingFlag()).isEqualTo(MatchingStatus.YES);
+        assertThat(roadmapList.get(0).getCourse().getId()).isEqualTo(1L);
+        assertThat(roadmapList.get(0).getCourse().getName()).isEqualTo("SKILL1");
+        assertThat(roadmapList.get(0).getCourse().getOrder()).isEqualTo(1);
+        assertThat(roadmapList.get(0).getCourse().getType()).isEqualTo(CourseType.SKILL);
+
+        assertThat(roadmapList.get(1).getCourse().getId()).isEqualTo(3L);
+        assertThat(roadmapList.get(1).getMatchingFlag()).isEqualTo(MatchingStatus.YES);
+        assertThat(roadmapList.get(1).getCourse().getName()).isEqualTo("CS2");
+        assertThat(roadmapList.get(1).getCourse().getOrder()).isEqualTo(2);
+        assertThat(roadmapList.get(1).getCourse().getType()).isEqualTo(CourseType.CS);
+
+        assertThat(roadmapList.get(2).getCourse().getId()).isEqualTo(4L);
+        assertThat(roadmapList.get(2).getMatchingFlag()).isEqualTo(MatchingStatus.NO);
+        assertThat(roadmapList.get(2).getCourse().getName()).isEqualTo("SKILL2");
+        assertThat(roadmapList.get(2).getCourse().getOrder()).isEqualTo(3);
+        assertThat(roadmapList.get(2).getCourse().getType()).isEqualTo(CourseType.SKILL);
+
+        assertThat(roadmapList.get(3).getCourse().getId()).isEqualTo(2L);
+        assertThat(roadmapList.get(3).getMatchingFlag()).isEqualTo(MatchingStatus.NO);
+        assertThat(roadmapList.get(3).getCourse().getName()).isEqualTo("CS1");
+        assertThat(roadmapList.get(3).getCourse().getOrder()).isEqualTo(3);
+        assertThat(roadmapList.get(3).getCourse().getType()).isEqualTo(CourseType.CS);
+    }
+}

--- a/src/test/java/io/devridge/api/service/CourseServiceTest.java
+++ b/src/test/java/io/devridge/api/service/CourseServiceTest.java
@@ -2,12 +2,9 @@ package io.devridge.api.service;
 
 import io.devridge.api.domain.companyinfo.*;
 import io.devridge.api.domain.roadmap.*;
-import io.devridge.api.domain.video.CourseVideoRepository;
 import io.devridge.api.dto.CourseDetailResponseDto;
-import io.devridge.api.dto.course.CompanyJobInfo;
 import io.devridge.api.dto.course.CourseListResponseDto;
 import io.devridge.api.handler.ex.CompanyInfoNotFoundException;
-import io.devridge.api.handler.ex.CompanyJobNotFoundException;
 import io.devridge.api.handler.ex.CourseNotFoundException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -21,6 +18,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -33,64 +31,195 @@ class CourseServiceTest {
     private CourseRepository courseRepository;
 
     @Mock
-    private CompanyJobRepository companyJobRepository;
+    private CompanyInfoRepository companyInfoRepository;
 
     @Mock
     private CourseDetailRepository courseDetailRepository;
 
     @Mock
-    private CompanyInfoRepository companyInfoRepository;
+    private RoadmapRepository roadmapRepository;
 
-    @DisplayName("코스리스트를 turn으로 모아서 리스트를 만들고 만약 SKILL과 SKILL 사이에 아무 것도 없다면 빈 리스트가 추가된다")
+    @DisplayName("회사, 직무, 상세 직무를 바탕으로 회사 정보를 찾고 이를 바탕으로 코스 목록을 만들어서 전달한다")
     @Test
-    public void getCourseList_success_test() {
+    public void get_course_list_success_test() {
         // given
-        Company company = Company.builder().id(1L).name("test company").build();
-        Job job = Job.builder().id(1L).name("test job").build();
-        CompanyJobInfo companyJobInfo = CompanyJobInfo.builder().companyName(company.getName()).jobName(job.getName()).build();
-
-        List<Course> courseList = makeCourseList(job);
-
-        long companyId = 1L;
-        long jobId = 1L;
+        CompanyInfo companyInfo = makeCompanyInfo();
+        List<Roadmap> roadmapList = new ArrayList<>();
 
         // stub
-        when(companyJobRepository.findCompanyJobInfo(companyId, jobId))
-                .thenReturn(Optional.of(companyJobInfo));
-
-        when(courseRepository.getCourseListByJob(jobId))
-                .thenReturn(courseList);
+        when(companyInfoRepository.findByCompanyIdAndJobIdAndDetailedPositionIdWithFetchJoin(anyLong(), anyLong(), anyLong())).thenReturn(Optional.of(companyInfo));
+        when(roadmapRepository.getRoadmapsIncludingCoursesByCompanyInfoId(anyLong())).thenReturn(roadmapList);
 
         // when
-        CourseListResponseDto courseListResponseDto = courseService.getCourseList(companyId, jobId);
+        CourseListResponseDto courseListResponseDto = courseService.getCourseList(1L, 1L, 1L);
 
         // then
-        assertThat(courseListResponseDto.getCourseList().size()).isEqualTo(5);
         assertThat(courseListResponseDto.getCompanyName()).isEqualTo("test company");
         assertThat(courseListResponseDto.getJobName()).isEqualTo("test job");
-        assertThat(courseListResponseDto.getCourseList().get(0).getIndex()).isEqualTo(0);
-        assertThat(courseListResponseDto.getCourseList().get(1).getIndex()).isEqualTo(1);
-        assertThat(courseListResponseDto.getCourseList().get(1).getCourses().size()).isEqualTo(0);
-        assertThat(courseListResponseDto.getCourseList().get(2).getCourses().get(0).getName()).isEqualTo("SKILL2");
-        assertThat(courseListResponseDto.getCourseList().get(2).getCourses().get(1).getName()).isEqualTo("CS1");
-        assertThat(courseListResponseDto.getCourseList().get(3).getCourses().get(0).getName()).isEqualTo("CS2");
-        assertThat(courseListResponseDto.getCourseList().get(4).getCourses().get(0).getName()).isEqualTo("SKILL3");
+        assertThat(courseListResponseDto.getCourseList().size()).isEqualTo(0);
     }
 
-    @DisplayName("회사와 직무가 일치하지 않으면 에러를 던진다")
+    @DisplayName("코스 목록을 만들 때 맨 처음 SKILL 타입이 나오면 빈 리스트를 추가한다.")
     @Test
-    public void getCourseList_fail_test() {
+    public void get_course_list_first_skill_success_test() {
         // given
-        long companyId = 1L;
-        long jobId = 2L;
+        CompanyInfo companyInfo = makeCompanyInfo();
+        List<Roadmap> roadmapList = new ArrayList<>();
+
+        Course course1 = Course.builder().id(1L).name("SKILL1").type(CourseType.SKILL).order(2).job(companyInfo.getJob()).build();
+        roadmapList.add(Roadmap.builder().course(course1).companyInfo(companyInfo).matchingFlag(MatchingStatus.NO).build());
 
         // stub
-        when(companyJobRepository.findCompanyJobInfo(companyId, jobId))
-                .thenReturn(Optional.empty());
+        when(companyInfoRepository.findByCompanyIdAndJobIdAndDetailedPositionIdWithFetchJoin(anyLong(), anyLong(), anyLong())).thenReturn(Optional.of(companyInfo));
+        when(roadmapRepository.getRoadmapsIncludingCoursesByCompanyInfoId(anyLong())).thenReturn(roadmapList);
+
+        // when
+        CourseListResponseDto courseListResponseDto = courseService.getCourseList(1L, 1L, 1L);
+
+        // then
+        assertThat(courseListResponseDto.getCourseList().size()).isEqualTo(2);
+        assertThat(courseListResponseDto.getCourseList().get(0).getIndex()).isEqualTo(0);
+        assertThat(courseListResponseDto.getCourseList().get(0).getCourses()).isEmpty();
+        assertThat(courseListResponseDto.getCourseList().get(1).getIndex()).isEqualTo(1);
+        assertThat(courseListResponseDto.getCourseList().get(1).getCourses().size()).isEqualTo(1);
+        assertThat(courseListResponseDto.getCourseList().get(1).getCourses().get(0).getId()).isEqualTo(1L);
+        assertThat(courseListResponseDto.getCourseList().get(1).getCourses().get(0).getName()).isEqualTo("SKILL1");
+        assertThat(courseListResponseDto.getCourseList().get(1).getCourses().get(0).getType()).isEqualTo(CourseType.SKILL);
+        assertThat(courseListResponseDto.getCourseList().get(1).getCourses().get(0).getMatchingFlag()).isEqualTo(MatchingStatus.NO);
+        assertThat(courseListResponseDto.getCourseList().get(1).getCourses().get(0).getOrder()).isEqualTo(2);
+    }
+
+    @DisplayName("코스 목록을 만들 때 맨 처음 CS 타입이 나오면 빈 리스트를 추가하지 않는다.")
+    @Test
+    public void get_course_list_first_cs_success_test() {
+        // given
+        CompanyInfo companyInfo = makeCompanyInfo();
+        List<Roadmap> roadmapList = new ArrayList<>();
+
+        Course course1 = Course.builder().id(1L).name("CS1").type(CourseType.CS).order(1).job(companyInfo.getJob()).build();
+        roadmapList.add(Roadmap.builder().course(course1).companyInfo(companyInfo).matchingFlag(MatchingStatus.YES).build());
+
+        // stub
+        when(companyInfoRepository.findByCompanyIdAndJobIdAndDetailedPositionIdWithFetchJoin(anyLong(), anyLong(), anyLong())).thenReturn(Optional.of(companyInfo));
+        when(roadmapRepository.getRoadmapsIncludingCoursesByCompanyInfoId(anyLong())).thenReturn(roadmapList);
+
+        // when
+        CourseListResponseDto courseListResponseDto = courseService.getCourseList(1L, 1L, 1L);
+
+        // then
+        assertThat(courseListResponseDto.getCourseList().size()).isEqualTo(1);
+        assertThat(courseListResponseDto.getCourseList().get(0).getIndex()).isEqualTo(0);
+        assertThat(courseListResponseDto.getCourseList().get(0).getCourses().size()).isEqualTo(1);
+        assertThat(courseListResponseDto.getCourseList().get(0).getCourses().get(0).getId()).isEqualTo(1L);
+        assertThat(courseListResponseDto.getCourseList().get(0).getCourses().get(0).getName()).isEqualTo("CS1");
+        assertThat(courseListResponseDto.getCourseList().get(0).getCourses().get(0).getType()).isEqualTo(CourseType.CS);
+        assertThat(courseListResponseDto.getCourseList().get(0).getCourses().get(0).getMatchingFlag()).isEqualTo(MatchingStatus.YES);
+        assertThat(courseListResponseDto.getCourseList().get(0).getCourses().get(0).getOrder()).isEqualTo(1);
+    }
+
+    @DisplayName("SKILL 다음에 SKILL이 나오면 중간에 빈 리스트를 추가한다.")
+    @Test
+    public void get_course_list_skill_between_skill_success_test() {
+        // given
+        CompanyInfo companyInfo = makeCompanyInfo();
+        List<Roadmap> roadmapList = new ArrayList<>();
+
+        Course course1 = Course.builder().id(1L).name("CS1").type(CourseType.CS).order(1).job(companyInfo.getJob()).build();
+        Course course2 = Course.builder().id(2L).name("SKILL1").type(CourseType.SKILL).order(2).job(companyInfo.getJob()).build();
+        Course course3 = Course.builder().id(3L).name("SKILL2").type(CourseType.SKILL).order(4).job(companyInfo.getJob()).build();
+        roadmapList.add(Roadmap.builder().course(course1).companyInfo(companyInfo).matchingFlag(MatchingStatus.NO).build());
+        roadmapList.add(Roadmap.builder().course(course2).companyInfo(companyInfo).matchingFlag(MatchingStatus.YES).build());
+        roadmapList.add(Roadmap.builder().course(course3).companyInfo(companyInfo).matchingFlag(MatchingStatus.YES).build());
+
+        // stub
+        when(companyInfoRepository.findByCompanyIdAndJobIdAndDetailedPositionIdWithFetchJoin(anyLong(), anyLong(), anyLong())).thenReturn(Optional.of(companyInfo));
+        when(roadmapRepository.getRoadmapsIncludingCoursesByCompanyInfoId(anyLong())).thenReturn(roadmapList);
+
+        // when
+        CourseListResponseDto courseListResponseDto = courseService.getCourseList(1L, 1L, 1L);
+
+        // then
+        assertThat(courseListResponseDto.getCourseList().size()).isEqualTo(4);
+        assertThat(courseListResponseDto.getCourseList().get(0).getCourses().get(0).getName()).isEqualTo("CS1");
+        assertThat(courseListResponseDto.getCourseList().get(0).getCourses().get(0).getType()).isEqualTo(CourseType.CS);
+        assertThat(courseListResponseDto.getCourseList().get(1).getCourses().get(0).getName()).isEqualTo("SKILL1");
+        assertThat(courseListResponseDto.getCourseList().get(1).getCourses().get(0).getType()).isEqualTo(CourseType.SKILL);
+        assertThat(courseListResponseDto.getCourseList().get(2).getCourses()).isEmpty();
+        assertThat(courseListResponseDto.getCourseList().get(3).getCourses().get(0).getName()).isEqualTo("SKILL2");
+        assertThat(courseListResponseDto.getCourseList().get(3).getCourses().get(0).getType()).isEqualTo(CourseType.SKILL);
+    }
+
+    @DisplayName("SKILL 다음에 CS가 나오면 빈 리스트를 추가 하지 않는다.")
+    @Test
+    public void get_course_list_skill_between_cs_success_test() {
+        // given
+        CompanyInfo companyInfo = makeCompanyInfo();
+        List<Roadmap> roadmapList = new ArrayList<>();
+
+        Course course1 = Course.builder().id(1L).name("CS1").type(CourseType.CS).order(1).job(companyInfo.getJob()).build();
+        Course course2 = Course.builder().id(2L).name("SKILL1").type(CourseType.SKILL).order(2).job(companyInfo.getJob()).build();
+        Course course3 = Course.builder().id(3L).name("CS2").type(CourseType.CS).order(4).job(companyInfo.getJob()).build();
+        roadmapList.add(Roadmap.builder().course(course1).companyInfo(companyInfo).matchingFlag(MatchingStatus.NO).build());
+        roadmapList.add(Roadmap.builder().course(course2).companyInfo(companyInfo).matchingFlag(MatchingStatus.YES).build());
+        roadmapList.add(Roadmap.builder().course(course3).companyInfo(companyInfo).matchingFlag(MatchingStatus.YES).build());
+
+        // stub
+        when(companyInfoRepository.findByCompanyIdAndJobIdAndDetailedPositionIdWithFetchJoin(anyLong(), anyLong(), anyLong())).thenReturn(Optional.of(companyInfo));
+        when(roadmapRepository.getRoadmapsIncludingCoursesByCompanyInfoId(anyLong())).thenReturn(roadmapList);
+
+        // when
+        CourseListResponseDto courseListResponseDto = courseService.getCourseList(1L, 1L, 1L);
+
+        // then
+        assertThat(courseListResponseDto.getCourseList().size()).isEqualTo(3);
+        assertThat(courseListResponseDto.getCourseList().get(0).getCourses().get(0).getName()).isEqualTo("CS1");
+        assertThat(courseListResponseDto.getCourseList().get(0).getCourses().get(0).getType()).isEqualTo(CourseType.CS);
+        assertThat(courseListResponseDto.getCourseList().get(1).getCourses().get(0).getName()).isEqualTo("SKILL1");
+        assertThat(courseListResponseDto.getCourseList().get(1).getCourses().get(0).getType()).isEqualTo(CourseType.SKILL);
+        assertThat(courseListResponseDto.getCourseList().get(2).getCourses().get(0).getName()).isEqualTo("CS2");
+        assertThat(courseListResponseDto.getCourseList().get(2).getCourses().get(0).getType()).isEqualTo(CourseType.CS);
+    }
+
+    @DisplayName("같은 순서를 가진 코스는 같은 리스트에 들어간다.")
+    @Test
+    public void same_order_course_is_same_list() {
+        // given
+        CompanyInfo companyInfo = makeCompanyInfo();
+        List<Roadmap> roadmapList = new ArrayList<>();
+
+        Course course1 = Course.builder().id(1L).name("CS1").type(CourseType.CS).order(1).job(companyInfo.getJob()).build();
+        Course course2 = Course.builder().id(1L).name("CS2").type(CourseType.CS).order(1).job(companyInfo.getJob()).build();
+        Course course3 = Course.builder().id(1L).name("CS3").type(CourseType.CS).order(1).job(companyInfo.getJob()).build();
+        roadmapList.add(Roadmap.builder().course(course1).companyInfo(companyInfo).matchingFlag(MatchingStatus.NO).build());
+        roadmapList.add(Roadmap.builder().course(course2).companyInfo(companyInfo).matchingFlag(MatchingStatus.YES).build());
+        roadmapList.add(Roadmap.builder().course(course3).companyInfo(companyInfo).matchingFlag(MatchingStatus.YES).build());
+
+        // stub
+        when(companyInfoRepository.findByCompanyIdAndJobIdAndDetailedPositionIdWithFetchJoin(anyLong(), anyLong(), anyLong())).thenReturn(Optional.of(companyInfo));
+        when(roadmapRepository.getRoadmapsIncludingCoursesByCompanyInfoId(anyLong())).thenReturn(roadmapList);
+
+        // when
+        CourseListResponseDto courseListResponseDto = courseService.getCourseList(1L, 1L, 1L);
+
+        // then
+        assertThat(courseListResponseDto.getCourseList().size()).isEqualTo(1);
+        assertThat(courseListResponseDto.getCourseList().get(0).getCourses().get(0).getName()).isEqualTo("CS1");
+        assertThat(courseListResponseDto.getCourseList().get(0).getCourses().get(0).getType()).isEqualTo(CourseType.CS);
+        assertThat(courseListResponseDto.getCourseList().get(0).getCourses().get(1).getName()).isEqualTo("CS2");
+        assertThat(courseListResponseDto.getCourseList().get(0).getCourses().get(1).getType()).isEqualTo(CourseType.CS);
+        assertThat(courseListResponseDto.getCourseList().get(0).getCourses().get(2).getName()).isEqualTo("CS3");
+        assertThat(courseListResponseDto.getCourseList().get(0).getCourses().get(2).getType()).isEqualTo(CourseType.CS);
+    }
+
+    @DisplayName("코스 리스트를 찾을 때 회사 정보를 찾을 수 없으면 예외를 전달한다")
+    @Test
+    public void course_list_not_found_company_info_fail_test() {
+        // stub
+        when(companyInfoRepository.findByCompanyIdAndJobIdAndDetailedPositionIdWithFetchJoin(anyLong(), anyLong(), anyLong())).thenReturn(Optional.empty());
 
         // when & then
-        assertThatThrownBy(() -> courseService.getCourseList(companyId, jobId))
-                .isInstanceOf(CompanyJobNotFoundException.class);
+        assertThatThrownBy(() -> courseService.getCourseList(1L, 1L, 1L))
+                .isInstanceOf(CompanyInfoNotFoundException.class);
     }
 
     @DisplayName("코스, 회사, 직무, 서비스가 주어지면 CourseDetail 리스트를 정상적으로 반환한다")
@@ -101,7 +230,6 @@ class CourseServiceTest {
         Job job = Job.builder().id(1L).name("백엔드").build();
         DetailedPosition detailedPosition = DetailedPosition.builder().id(1L).name("Product").company(company).build();
         CompanyInfo companyInfo = CompanyInfo.builder().id(1L).job(job).detailedPosition(detailedPosition).company(company).build();
-
         Course course = Course.builder().id(1L).name("언어").job(job).build();
 
         //stub
@@ -144,7 +272,6 @@ class CourseServiceTest {
         Job job = Job.builder().id(1L).name("백엔드").build();
         DetailedPosition detailedPosition = DetailedPosition.builder().id(1L).name("Product").company(company).build();
         CompanyInfo companyInfo = CompanyInfo.builder().id(1L).company(company).job(job).detailedPosition(detailedPosition).build();
-
         Course course = Course.builder().id(1L).name("언어").job(job).build();
 
         //stub
@@ -156,14 +283,11 @@ class CourseServiceTest {
                 .isInstanceOf(CourseNotFoundException.class);
     }
 
-    private List<Course> makeCourseList(Job job) {
-        List<Course> courseList = new ArrayList<>();
-        courseList.add(Course.builder().id(1L).name("SKILL1").type(CourseType.SKILL).order(1).job(job).build());
-        courseList.add(Course.builder().id(3L).name("SKILL2").type(CourseType.SKILL).order(3).job(job).build());
-        courseList.add(Course.builder().id(2L).name("CS1").type(CourseType.CS).order(3).job(job).build());
-        courseList.add(Course.builder().id(4L).name("CS2").type(CourseType.CS).order(4).job(job).build());
-        courseList.add(Course.builder().id(5L).name("SKILL3").type(CourseType.SKILL).order(5).job(job).build());
-        return courseList;
+    private CompanyInfo makeCompanyInfo() {
+        Company company = Company.builder().id(1L).name("test company").build();
+        Job job = Job.builder().id(1L).name("test job").build();
+        DetailedPosition detailedPosition = DetailedPosition.builder().id(1L).name("test detailed position").build();
+        return CompanyInfo.builder().id(1L).company(company).job(job).detailedPosition(detailedPosition).build();
     }
 
     private List<CourseDetail> makeCourseDetailList(Course course) {

--- a/src/test/java/io/devridge/api/web/CourseControllerTest.java
+++ b/src/test/java/io/devridge/api/web/CourseControllerTest.java
@@ -1,22 +1,29 @@
 package io.devridge.api.web;
 
 import io.devridge.api.domain.companyinfo.*;
-import io.devridge.api.domain.roadmap.Course;
-import io.devridge.api.domain.roadmap.CourseRepository;
-import io.devridge.api.domain.roadmap.CourseType;
-import org.junit.jupiter.api.BeforeEach;
+import io.devridge.api.domain.roadmap.*;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -29,63 +36,136 @@ class CourseControllerTest {
 
     @Autowired
     private MockMvc mvc;
-    @Autowired
-    private CourseRepository courseRepository;
-    @Autowired
-    private JobRepository jobRepository;
-    @Autowired
-    private CompanyRepository companyRepository;
-    @Autowired
-    private CompanyJobRepository companyJobRepository;
-    
-    @BeforeEach
-    public void setUp() {
-        Company company = companyRepository.save(Company.builder().name("토스 증권").build());
-        Job job = jobRepository.save(Job.builder().name("백엔드").build());
-        companyJobRepository.save(CompanyJob.builder().company(company).job(job).build());
-        courseRepository.save(Course.builder().name("SKILL1").type(CourseType.SKILL).order(1).job(job).build());
-        courseRepository.save(Course.builder().name("SKILL2").type(CourseType.SKILL).order(3).job(job).build());
-        courseRepository.save(Course.builder().name("CS1").type(CourseType.CS).order(3).job(job).build());
-        courseRepository.save(Course.builder().name("CS2").type(CourseType.CS).order(4).job(job).build());
-    }
 
-    @DisplayName("코스 조회 성공")
+    @MockBean
+    private RoadmapRepository roadmapRepository;
+
+    @MockBean
+    private CompanyInfoRepository companyInfoRepository;
+
+    @DisplayName("특정 회사, 직무, 상세 직무 기준으로 코스 목록을 응답한다")
     @Test
-    public void courses_success_test() throws Exception {
+    public void course_list_success_test() throws Exception {
         // given
-        long companyId = 1L;
-        long jobId = 1L;
+        Company company = Company.builder().id(1L).name("test company").build();
+        Job job = Job.builder().id(1L).name("test job").build();
+        DetailedPosition detailedPosition = DetailedPosition.builder().id(1L).name("test detailed position").build();
+        CompanyInfo companyInfo = CompanyInfo.builder().id(1L).company(company).job(job).detailedPosition(detailedPosition).build();
+
+        Course course1 = Course.builder().id(1L).name("SKILL1").type(CourseType.SKILL).order(1).job(job).build();
+        Course course2 = Course.builder().id(2L).name("SKILL2").type(CourseType.SKILL).order(3).job(job).build();
+        Course course3 = Course.builder().id(3L).name("CS1").type(CourseType.CS).order(3).job(job).build();
+        Course course4 = Course.builder().id(4L).name("CS2").type(CourseType.CS).order(4).job(job).build();
+
+        List<Roadmap> roadmapList = new ArrayList<>();
+        roadmapList.add(Roadmap.builder().course(course1).companyInfo(companyInfo).matchingFlag(MatchingStatus.YES).build());
+        roadmapList.add(Roadmap.builder().course(course2).companyInfo(companyInfo).matchingFlag(MatchingStatus.YES).build());
+        roadmapList.add(Roadmap.builder().course(course3).companyInfo(companyInfo).matchingFlag(MatchingStatus.NO).build());
+        roadmapList.add(Roadmap.builder().course(course4).companyInfo(companyInfo).matchingFlag(MatchingStatus.NO).build());
+
+        // stub
+        when(companyInfoRepository.findByCompanyIdAndJobIdAndDetailedPositionIdWithFetchJoin(company.getId(), job.getId(), detailedPosition.getId())).thenReturn(Optional.of(companyInfo));
+        when(roadmapRepository.getRoadmapsIncludingCoursesByCompanyInfoId(companyInfo.getId())).thenReturn(roadmapList);
 
         // when
         ResultActions resultActions = mvc.perform(
                 get("/courses")
-                        .param("company", Long.toString(companyId))
-                        .param("job", Long.toString(jobId))
+                        .param("company", Long.toString(1L))
+                        .param("job", Long.toString(1L))
+                        .param("detailedPosition", Long.toString(1L))
         );
 
         // then
         resultActions.andExpect(status().isOk());
         resultActions.andExpect(jsonPath("$.status").value("success"));
-        resultActions.andExpect(jsonPath("$.data.courseList").isNotEmpty());
+        resultActions.andExpect(jsonPath("$.message").value("요청 성공"));
+        resultActions.andExpect(jsonPath("$.data.companyName").value("test company"));
+        resultActions.andExpect(jsonPath("$.data.jobName").value("test job"));
+        resultActions.andExpect(jsonPath("$.data.courseList", hasSize(5)));
+        
+        // 첫번째 skill이 나오면 빈 리스트
+        resultActions.andExpect(jsonPath("$.data.courseList[0].index").value(0));
+        resultActions.andExpect(jsonPath("$.data.courseList[0].courses", hasSize(0)));
+
+        resultActions.andExpect(jsonPath("$.data.courseList[1].index").value(1));
+        resultActions.andExpect(jsonPath("$.data.courseList[1].courses[0].id").value(1));
+        resultActions.andExpect(jsonPath("$.data.courseList[1].courses[0].name").value("SKILL1"));
+        resultActions.andExpect(jsonPath("$.data.courseList[1].courses[0].type").value("SKILL"));
+        resultActions.andExpect(jsonPath("$.data.courseList[1].courses[0].matchingFlag").value("YES"));
+        
+        // skill과 skill 사이는 빈 리스트
+        resultActions.andExpect(jsonPath("$.data.courseList[2].index").value(2));
+        resultActions.andExpect(jsonPath("$.data.courseList[2].courses", hasSize(0)));
+
+        // order가 같으면 같은 리스트에 들어간다.
+        resultActions.andExpect(jsonPath("$.data.courseList[3].index").value(3));
+        resultActions.andExpect(jsonPath("$.data.courseList[3].courses[0].id").value(2));
+        resultActions.andExpect(jsonPath("$.data.courseList[3].courses[0].name").value("SKILL2"));
+        resultActions.andExpect(jsonPath("$.data.courseList[3].courses[0].type").value("SKILL"));
+        resultActions.andExpect(jsonPath("$.data.courseList[3].courses[0].matchingFlag").value("YES"));
+        resultActions.andExpect(jsonPath("$.data.courseList[3].courses[1].id").value(3));
+        resultActions.andExpect(jsonPath("$.data.courseList[3].courses[1].name").value("CS1"));
+        resultActions.andExpect(jsonPath("$.data.courseList[3].courses[1].type").value("CS"));
+        resultActions.andExpect(jsonPath("$.data.courseList[3].courses[1].matchingFlag").value("NO"));
+
+        resultActions.andExpect(jsonPath("$.data.courseList[4].index").value(4));
+        resultActions.andExpect(jsonPath("$.data.courseList[4].courses[0].id").value(4));
+        resultActions.andExpect(jsonPath("$.data.courseList[4].courses[0].name").value("CS2"));
+        resultActions.andExpect(jsonPath("$.data.courseList[4].courses[0].type").value("CS"));
+        resultActions.andExpect(jsonPath("$.data.courseList[4].courses[0].matchingFlag").value("NO"));
     }
 
-    @DisplayName("코스 조회 실패 - 회사, 직무 정보 오류")
+    @DisplayName("코스 리스트 조회시 잘못된 정보를 보내면 에러를 응답한다.")
     @ParameterizedTest
-    @CsvSource({
-            "1, 100",
-            "100, 1",
-    })
-    public void courses_fail_test(long companyId, long jobId) throws Exception {
+    @MethodSource("invalidACourseListArgument")
+    public void courses_list_request_fail_test(String companyId, String jobId, String detailedId) throws Exception {
         // given & when
         ResultActions resultActions = mvc.perform(
                 get("/courses")
-                        .param("company", Long.toString(companyId))
-                        .param("job", Long.toString(jobId))
+                        .param("company", companyId)
+                        .param("job", jobId)
+                        .param("detailedPosition", detailedId)
         );
 
         // then
         resultActions.andExpect(status().isBadRequest());
         resultActions.andExpect(jsonPath("$.status").value("error"));
-        resultActions.andExpect(jsonPath("$.message").value("회사와 직무에 일치 하는 정보가 없습니다."));
+        resultActions.andExpect(jsonPath("$.message").value("잘못된 형식 요청"));
+        resultActions.andExpect(jsonPath("$.data").isEmpty());
+    }
+
+    @DisplayName("코스 리스트 조회시 회사정보가 존재하지 않으면 에러를 응답한다")
+    @Test
+    public void courses_fail_test() throws Exception {
+        // stub
+        when(companyInfoRepository.findByCompanyIdAndJobIdAndDetailedPositionIdWithFetchJoin(anyLong(), anyLong(), anyLong())).thenReturn(Optional.empty());
+
+        // when
+        ResultActions resultActions = mvc.perform(
+                get("/courses")
+                        .param("company", "1")
+                        .param("job", "1")
+                        .param("detailedPosition", "1")
+        );
+        
+        // then
+        resultActions.andExpect(status().isBadRequest());
+        resultActions.andExpect(jsonPath("$.status").value("error"));
+        resultActions.andExpect(jsonPath("$.message").value("회사, 직무, 서비스에 일치 하는 회사 정보가 없습니다."));
+        resultActions.andExpect(jsonPath("$.data").isEmpty());
+    }
+
+    static Stream<Arguments> invalidACourseListArgument() {
+        return Stream.of(
+                Arguments.of("", "1", "1"),
+                Arguments.of(" ", "1", "1"),
+                Arguments.of("wrong", "1", "1"),
+                Arguments.of("1", "", "1"),
+                Arguments.of("1", " ", "1"),
+                Arguments.of("1", "wrong", "1"),
+                Arguments.of("1", "1", ""),
+                Arguments.of("1", "1", " "),
+                Arguments.of("1", "1", "wrong")
+        );
     }
 }


### PR DESCRIPTION
### 프론트 요구사항
1.  처음에 SKILL이 나오면 빈 리스트를 앞에 추가, CS가 나오면 추가 X
2.  SKILL과 다음 순서(order)에 SKILL이 나오면 빈 리스트 추가. SKILL 다음 순서(order)에 CS가 나오면 빈 리스트 추가 X
3.  같은 순서(order)를 가진 코스는 리스트로 모으고 하나만 있더라도 리스트에 넣기

### 구현 사항
- 코스 리스트 API 기능
- 코스 리스트 테스트 