### PR TITLE
스터디 상태 변경 API

### DIFF
--- a/src/main/java/io/devridge/api/config/AuthEndpoints.java
+++ b/src/main/java/io/devridge/api/config/AuthEndpoints.java
@@ -5,8 +5,8 @@ import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class AuthEndpoints {
-    public static final String[] REQUIRED_STATIC_AUTH_URLS = { "/required_login/test", "/users/channeltalkinfo", "/videos/like" };
-    public static final String[] REQUIRED_WILDCARD_AUTH_URLS = { "/required_login/wild_test/**", "/required_login/**/wild_test", "/**/required_login/wild_test" };
+    public static final String[] REQUIRED_STATIC_AUTH_URLS = { "/required_login/test", "/users/channeltalkinfo", "/videos/like"};
+    public static final String[] REQUIRED_WILDCARD_AUTH_URLS = { "/required_login/wild_test/**", "/required_login/**/wild_test", "/**/required_login/wild_test", "/courses/**/change-studystatus"};
     public static final String[] OPTIONAL_STATIC_AUTH_URLS = { "/courses", "/optional_login/test", "/videos" };
     public static final String[] OPTIONAL_WILDCARD_AUTH_URLS = { "/courses/**", "/optional_login/wild_test/**", "/optional_login/**/wild_test", "/**/optional_login/wild_test" };
 }

--- a/src/main/java/io/devridge/api/domain/roadmap/RoadmapRepository.java
+++ b/src/main/java/io/devridge/api/domain/roadmap/RoadmapRepository.java
@@ -23,4 +23,6 @@ public interface RoadmapRepository extends JpaRepository<Roadmap, Long> {
             "JOIN FETCH r.course c " +
             "WHERE r.course.id = :courseId AND r.companyInfo.id = :companyInfoId")
     Optional<Roadmap> findRoadmapWithCourseByCourseIdAndCompanyInfoId(Long courseId, Long companyInfoId);
+
+    Optional<Roadmap> findByCourseIdAndCompanyInfoId(Long courseId, Long companyInfoId);
 }

--- a/src/main/java/io/devridge/api/domain/user/UserRoadmap.java
+++ b/src/main/java/io/devridge/api/domain/user/UserRoadmap.java
@@ -33,6 +33,10 @@ public class UserRoadmap extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     private Roadmap roadmap;
 
+    public void changeStudyStatus(StudyStatus studyStatus) {
+        this.studyStatus = studyStatus;
+    }
+
     @Builder
     public UserRoadmap(Long id, StudyStatus studyStatus, User user, Roadmap roadmap) {
         this.id = id;

--- a/src/main/java/io/devridge/api/dto/course/ChangeStudyStatusRequestDto.java
+++ b/src/main/java/io/devridge/api/dto/course/ChangeStudyStatusRequestDto.java
@@ -1,0 +1,24 @@
+package io.devridge.api.dto.course;
+
+import lombok.Getter;
+
+import javax.validation.constraints.NotNull;
+
+@Getter
+public class ChangeStudyStatusRequestDto {
+    @NotNull
+    private Long companyId;
+    @NotNull
+    private Long jobId;
+    @NotNull
+    private Long detailedPositionId;
+    @NotNull
+    private StudyStatusDto studyStatus;
+
+    public ChangeStudyStatusRequestDto(Long companyId, Long jobId, Long detailedPositionId, StudyStatusDto studyStatusDto) {
+        this.companyId = companyId;
+        this.jobId = jobId;
+        this.detailedPositionId = detailedPositionId;
+        this.studyStatus = studyStatusDto;
+    }
+}

--- a/src/main/java/io/devridge/api/dto/course/StudyStatusDto.java
+++ b/src/main/java/io/devridge/api/dto/course/StudyStatusDto.java
@@ -1,0 +1,5 @@
+package io.devridge.api.dto.course;
+
+public enum StudyStatusDto {
+    BEFORE_STUDYING, STUDYING, STUDY_END
+}

--- a/src/main/java/io/devridge/api/dto/coursevideo/LikeCourseVideoRequestDto.java
+++ b/src/main/java/io/devridge/api/dto/coursevideo/LikeCourseVideoRequestDto.java
@@ -3,6 +3,7 @@ package io.devridge.api.dto.coursevideo;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 
 @Getter

--- a/src/main/java/io/devridge/api/handler/CourseExceptionHandler.java
+++ b/src/main/java/io/devridge/api/handler/CourseExceptionHandler.java
@@ -13,6 +13,12 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @RestControllerAdvice
 public class CourseExceptionHandler {
 
+    @ExceptionHandler(CourseNotFoundException.class)
+    public ResponseEntity<ApiResponse<Object>> handleCourseNotFoundException(CourseNotFoundException exception) {
+        log.error("CourseNotFoundException = {}", exception.getMessage());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ApiResponse.error(exception.getMessage()));
+    }
+
     @ExceptionHandler(CompanyJobNotFoundException.class)
     public ResponseEntity<ApiResponse<Object>> handleCompanyJobNotFoundException(CompanyJobNotFoundException exception) {
         log.error("CompanyJobNotFoundException = {}", exception.getMessage());

--- a/src/main/java/io/devridge/api/service/CompanyInfoService.java
+++ b/src/main/java/io/devridge/api/service/CompanyInfoService.java
@@ -25,7 +25,7 @@ public class CompanyInfoService {
     private final JobDetailedPositionService jobDetailedPositionService;
 
     public CompanyInfo validateCompanyInfo(Long companyId, Long jobId, Long detailedPositionId) {
-        return companyInfoRepository.findByCompanyIdAndJobIdAndDetailedPositionId(companyId, jobId, detailedPositionId).orElseThrow(() -> new CompanyInfoNotFoundException("해당하는 회사 정보를 찾을 수 없습니다. 먼저 회사 정보를 등록해주세요."));
+        return companyInfoRepository.findByCompanyIdAndJobIdAndDetailedPositionId(companyId, jobId, detailedPositionId).orElseThrow(() -> new CompanyInfoNotFoundException("해당하는 회사 정보를 찾을 수 없습니다."));
     }
 
     /**

--- a/src/main/java/io/devridge/api/web/CourseController.java
+++ b/src/main/java/io/devridge/api/web/CourseController.java
@@ -3,6 +3,7 @@ package io.devridge.api.web;
 import io.devridge.api.config.auth.LoginUser;
 import io.devridge.api.dto.CourseDetailResponseDto;
 import io.devridge.api.dto.common.ApiResponse;
+import io.devridge.api.dto.course.ChangeStudyStatusRequestDto;
 import io.devridge.api.dto.course.CourseListResponseDto;
 import io.devridge.api.service.CourseService;
 import lombok.RequiredArgsConstructor;
@@ -10,6 +11,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
 
 
 @RestController
@@ -41,5 +44,16 @@ public class CourseController {
         CourseDetailResponseDto courseDetailResponseDto = courseService.getCourseDetailList(courseId, companyId, jobId, detailedPositionId, loginUser);
 
         return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success(courseDetailResponseDto));
+    }
+
+    @PostMapping("/courses/{courseId}/change-studystatus")
+    public ResponseEntity<ApiResponse<Object>> changeStudyStatus(
+            @PathVariable Long courseId,
+            @Valid @RequestBody ChangeStudyStatusRequestDto changeStudyStatusRequestDto,
+            @AuthenticationPrincipal LoginUser loginUser) {
+
+        courseService.changeStudyStatus(courseId, changeStudyStatusRequestDto, loginUser);
+
+        return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success("학습 상태를 성공적으로 변경하였습니다."));
     }
 }

--- a/src/main/java/io/devridge/api/web/CourseVideoController.java
+++ b/src/main/java/io/devridge/api/web/CourseVideoController.java
@@ -11,6 +11,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import javax.validation.Valid;
+
 @RestController
 @RequiredArgsConstructor
 public class CourseVideoController {
@@ -32,7 +34,7 @@ public class CourseVideoController {
 
     @PostMapping("/videos/like")
     public ResponseEntity<ApiResponse<Object>> clickLikeOnCourseVideo(
-            @RequestBody LikeCourseVideoRequestDto likeCourseVideoRequestDto,
+            @Valid @RequestBody LikeCourseVideoRequestDto likeCourseVideoRequestDto,
             @AuthenticationPrincipal LoginUser loginUser) {
 
         boolean result = courseVideoService.clickLikeOnCourseVideo(likeCourseVideoRequestDto, loginUser);


### PR DESCRIPTION
### 스터디 상태 변경 API 구현
<요청: POST /courses/{courseId}/change-studystatus>
<img width="1015" alt="스크린샷 2023-10-31 오후 3 41 06" src="https://github.com/DEVRIDGE/devridge-api/assets/83588265/5d4f450a-cb4d-453c-8859-b4d0ae41bf4c">
studyStatus 필드에는 BEFORE_STUDYING, STUDYING, STUDY_END가 들어감
<응답>
-정상
<img width="1031" alt="스크린샷 2023-10-31 오후 3 41 12" src="https://github.com/DEVRIDGE/devridge-api/assets/83588265/0ba06c74-3fcf-44b7-8e75-2cb5078842e6">


** 다만 현재 상태에서는 프론트에 코스목록 줄때 학습상태가 학습 전일때 studyStatus에 null이 들어가고 학습 중, 학습 완료 상태는 잘 들어감.