### PR TITLE
fix: ci에서는 체크만 cd(delivery)에서 docker image로 변환시키기

### DIFF
--- a/.github/workflows/continuous_delivery.yml
+++ b/.github/workflows/continuous_delivery.yml
@@ -10,10 +10,19 @@ jobs:
     runs-on: ubuntu-latest
     environment: devridge docker  # 환경 이름을 지정합니다.
     steps:
-      - name: Download build artifact
-        uses: actions/download-artifact@v2
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
         with:
-          name: devridge-artifact
+          java-version: '11'
+          distribution: 'adopt'
+
+      - name: Build with Gradle
+        run: |
+          chmod +x ./gradlew
+          ./gradlew build
 
       - name: Set up Docker
         uses: docker/setup-buildx-action@v1

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -26,9 +26,3 @@ jobs:
 
       - name: Run tests
         run: ./gradlew test
-
-      - name: Upload build artifacts
-        uses: actions/upload-artifact@v2
-        with:
-          name: devridge-artifact
-          path: build/libs/*.jar


### PR DESCRIPTION
## github action의 artifact를 저장하고 사용하려면 같은 workflow여야한다.

### 해결 방법

- 외부 저장소를 사용
- 동일한 workflow에서 처리
- 다른 방식으로 아티펙트 전달 (docker image 만들고 cd에서 다시 빌드)
